### PR TITLE
CDAP-12225 fix row conversion bug with null fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>co.cask.hydrator</groupId>
   <artifactId>dynamic-spark</artifactId>
-  <version>1.7.2</version>
+  <version>1.7.3</version>
 
   <properties>
     <!-- properties for script build step that creates the config files for the artifacts -->

--- a/src/main/java/co/cask/hydrator/plugin/spark/dynamic/SparkDataFrames.java
+++ b/src/main/java/co/cask/hydrator/plugin/spark/dynamic/SparkDataFrames.java
@@ -353,6 +353,7 @@ public final class SparkDataFrames {
 
           // If the value is null for the field, just continue without setting anything to the StructuredRecord
           if (row.isNullAt(idx)) {
+            idx++;
             continue;
           }
 

--- a/src/test/java/co/cask/hydrator/plugin/spark/dynamic/SparkDataFramesTest.java
+++ b/src/test/java/co/cask/hydrator/plugin/spark/dynamic/SparkDataFramesTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.spark.dynamic;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import org.apache.spark.sql.Row;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test SparkDataFrames utility methods.
+ */
+public class SparkDataFramesTest {
+
+  @Test
+  public void testNullFieldRowConversion() {
+    Schema schema = Schema.recordOf("x",
+                                    Schema.Field.of("x", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
+                                    Schema.Field.of("y", Schema.nullableOf(Schema.of(Schema.Type.INT))));
+    StructuredRecord expected = StructuredRecord.builder(schema).set("y", 5).build();
+
+    Row row = SparkDataFrames.toRow(expected, SparkDataFrames.toStructType(schema));
+    StructuredRecord actual = SparkDataFrames.fromRow(row, schema);
+    Assert.assertEquals(expected, actual);
+  }
+}


### PR DESCRIPTION
Fixed a bug in the logic to transform a Spark Row back into a
StructuredRecord. If the Row contained a null field, all subsequent
fields in the StructuredRecord would be incorrectly set.