### PR TITLE
Use reflection to call SQLContext.createDataFrame

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>co.cask.hydrator</groupId>
   <artifactId>dynamic-spark</artifactId>
-  <version>2.0.5</version>
+  <version>2.0.6</version>
 
   <properties>
     <!-- properties for script build step that creates the config files for the artifacts -->


### PR DESCRIPTION
- Spark 1 and Spark 2 are not binary compatible for the method